### PR TITLE
Add ReportGrindShopOpenOrders report and tests

### DIFF
--- a/p21api/config.py
+++ b/p21api/config.py
@@ -9,6 +9,7 @@ from pydantic_settings import BaseSettings
 
 from .report_base import ReportBase
 from .report_daily_sales import ReportDailySales
+from .report_grind_shop_open_orders import ReportGrindShopOpenOrders
 from .report_inventory import ReportInventory
 from .report_inventory_value import ReportInventoryValue
 from .report_jarp import ReportJarp
@@ -162,6 +163,7 @@ class Config(BaseSettings):
                 ReportMonthlyInvoices,
                 ReportMonthlyConsolidation,
                 ReportJarp,
+                ReportGrindShopOpenOrders,
             ],
             "inventory": [
                 ReportInventory,

--- a/p21api/report_base.py
+++ b/p21api/report_base.py
@@ -13,6 +13,18 @@ logger = logging.getLogger(__name__)
 
 
 class ReportBase(ABC):
+    @staticmethod
+    def build_or_filter(
+        field: str, values: set[object], quote_strings: bool = True
+    ) -> str:
+        """Helper to build an OData OR filter string for a field and a set of values."""
+        if not values:
+            return ""
+        if quote_strings:
+            return " or ".join([f"{field} eq '{v}'" for v in values if v is not None])
+        else:
+            return " or ".join([f"{field} eq {v}" for v in values if v is not None])
+
     def __init__(
         self,
         client: "ODataClient",

--- a/p21api/report_grind_shop_open_orders.py
+++ b/p21api/report_grind_shop_open_orders.py
@@ -1,0 +1,182 @@
+import petl as etl
+
+from .report_base import ReportBase
+
+
+class ReportGrindShopOpenOrders(ReportBase):
+    @property
+    def file_name_prefix(self) -> str:
+        return "grind_shop_open_orders_"
+
+    def _run(self) -> None:
+        # Get order header data for grind shop orders (taker = 'RC')
+        order_hdr_data, url = self._client.query_odataservice(
+            endpoint="p21_view_oe_hdr",
+            selects=[
+                "customer_id",
+                "order_no",
+                "order_date",
+                "requested_date",
+                "promise_date",
+                "taker",
+                "delete_flag",
+                "completed",
+                "company_id",
+            ],
+            filters=[
+                "company_id eq 'CMS'",  # CMS Orders Only
+                "delete_flag eq 'N'",  # Not Deleted
+                "completed ne 'Y'",  # Order is not marked complete
+                "taker eq 'RC'",  # Grind Shop
+            ],
+            order_by=["customer_id asc", "order_no asc"],
+        )
+        if not order_hdr_data:
+            return
+
+        order_hdr = etl.fromdicts(order_hdr_data)
+        if self._debug:
+            etl.tocsv(order_hdr, self.file_name("order_hdr"))
+
+        # Get order line data for the orders
+        order_no_filters = " or ".join(
+            [
+                f"order_no eq '{order_no}'"
+                for order_no in {row["order_no"] for row in order_hdr_data}
+            ]
+        )
+
+        order_line_data, url = self._client.query_odataservice(
+            endpoint="p21_view_oe_line",
+            selects=[
+                "order_no",
+                "inv_mast_uid",
+                "qty_ordered",
+                "qty_allocated",
+                "qty_on_pick_tickets",
+                "qty_invoiced",
+                "qty_canceled",
+                "disposition",
+                "delete_flag",
+                "complete",
+            ],
+            filters=[
+                f"({order_no_filters})",
+                "delete_flag eq 'N'",  # Not Deleted
+                "complete ne 'Y'",  # Line is not marked complete
+            ],
+        )
+        if not order_line_data:
+            return
+
+        order_line = etl.fromdicts(order_line_data)
+        if self._debug:
+            etl.tocsv(order_line, self.file_name("order_line"))
+
+        # Get inventory master data for item details
+        inv_mast_uid_filters = " or ".join(
+            [
+                f"inv_mast_uid eq {inv_mast_uid}"
+                for inv_mast_uid in {row["inv_mast_uid"] for row in order_line_data}
+                if inv_mast_uid is not None
+            ]
+        )
+
+        if not inv_mast_uid_filters:
+            return
+
+        inv_mast_data, _ = self._client.query_odataservice(
+            endpoint="p21_view_inv_mast",
+            selects=[
+                "inv_mast_uid",
+                "item_id",
+                "item_desc",
+            ],
+            filters=[f"({inv_mast_uid_filters})"],
+        )
+        if not inv_mast_data:
+            return
+
+        inv_mast = etl.fromdicts(inv_mast_data)
+        if self._debug:
+            etl.tocsv(inv_mast, self.file_name("inv_mast"))
+
+        # Get customer data
+        customer_id_filters = " or ".join(
+            [
+                f"customer_id eq {customer_id}"
+                for customer_id in {row["customer_id"] for row in order_hdr_data}
+                if customer_id is not None
+            ]
+        )
+
+        customer_data, _ = self._client.query_odataservice(
+            endpoint="p21_view_customer",
+            selects=[
+                "customer_id",
+                "customer_name",
+            ],
+            filters=[f"({customer_id_filters})"],
+        )
+        if not customer_data:
+            return
+
+        customer = etl.fromdicts(customer_data)
+        if self._debug:
+            etl.tocsv(customer, self.file_name("customer"))
+
+        # Join order header with customer
+        order_customer_joined = etl.join(
+            order_hdr,
+            customer,
+            lkey="customer_id",
+            rkey="customer_id",
+        )
+
+        # Join with order lines
+        order_line_joined = etl.join(
+            order_customer_joined,
+            order_line,
+            lkey="order_no",
+            rkey="order_no",
+        )
+
+        # Join with inventory master for item details
+        final_joined = etl.join(
+            order_line_joined,
+            inv_mast,
+            lkey="inv_mast_uid",
+            rkey="inv_mast_uid",
+        )
+
+        # Select the desired columns matching the SQL query output
+        selected_columns = etl.cut(
+            final_joined,
+            "customer_id",
+            "customer_name",
+            "order_no",
+            "order_date",
+            "requested_date",
+            "promise_date",
+            "item_id",
+            "item_desc",
+            "qty_ordered",
+            "qty_allocated",
+            "qty_on_pick_tickets",
+            "qty_invoiced",
+            "qty_canceled",
+            "disposition",
+        )
+
+        # Sort the data
+        sorted_table = etl.sort(
+            selected_columns, key=["customer_id", "order_no", "item_id"]
+        )
+
+        # Filter items that start with KDB or PRE (assumptions from SQL comments)
+        filtered_table = etl.select(
+            sorted_table, lambda rec: rec.get("item_id", "").startswith(("KDB", "PRE"))
+        )
+
+        # Output the result to a CSV file
+        etl.tocsv(filtered_table, self.file_name("report"))

--- a/p21api/report_jarp.py
+++ b/p21api/report_jarp.py
@@ -44,11 +44,9 @@ class ReportJarp(ReportBase):
         if self._debug:
             etl.tocsv(invoice, self.file_name("invoice"))
 
-        invoice_ids_filter = " or ".join(
-            [
-                f"invoice_no eq '{invoice_id}'"
-                for invoice_id in {row["invoice_no"] for row in invoice_data}
-            ]
+        invoice_ids_filter = ReportBase.build_or_filter(
+            "invoice_no",
+            {row["invoice_no"] for row in invoice_data},
         )
         invoice_line_data, _ = self._client.query_odataservice(
             endpoint="p21_view_invoice_line",
@@ -94,12 +92,10 @@ class ReportJarp(ReportBase):
         if self._debug:
             etl.tocsv(sales_history, self.file_name("sales_history"))
 
-        supplier_id_filter = " or ".join(
-            [
-                f"supplier_id eq {supplier_id}"
-                for supplier_id in {row["supplier_id"] for row in sales_history_data}
-                if supplier_id is not None
-            ]
+        supplier_id_filter = ReportBase.build_or_filter(
+            "supplier_id",
+            {row["supplier_id"] for row in sales_history_data},
+            quote_strings=False,
         )
         supplier_data, _ = self._client.query_odataservice(
             endpoint="p21_view_inventory_supplier",

--- a/p21api/report_open_orders.py
+++ b/p21api/report_open_orders.py
@@ -47,11 +47,9 @@ class ReportOpenOrders(ReportBase):
         order = etl.fromdicts(order_data)
         if self._debug:
             etl.tocsv(order, self.file_name("order"))
-        order_no_filters = " or ".join(
-            [
-                f"order_no eq '{order_no}'"
-                for order_no in {row["order_no"] for row in order_data}
-            ]
+        order_no_filters = ReportBase.build_or_filter(
+            "order_no",
+            {row["order_no"] for row in order_data},
         )
 
         order_ack_line_data, _ = self._client.query_odataservice(

--- a/tests/reports/test_report_grind_shop_open_orders.py
+++ b/tests/reports/test_report_grind_shop_open_orders.py
@@ -1,0 +1,161 @@
+"""Tests for ReportGrindShopOpenOrders."""
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import Mock, patch
+
+
+class TestReportGrindShopOpenOrders:
+    """Test cases for ReportGrindShopOpenOrders."""
+
+    def test_file_name_prefix(self, mock_config, mock_odata_client):
+        """Test file name prefix for grind shop open orders report."""
+        from p21api.report_grind_shop_open_orders import ReportGrindShopOpenOrders
+
+        report = ReportGrindShopOpenOrders(
+            client=mock_odata_client,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            output_folder="test_output/",
+            debug=False,
+            config=mock_config,
+        )
+        assert report.file_name_prefix == "grind_shop_open_orders_"
+
+    @patch("petl.tocsv")
+    @patch("petl.fromdicts")
+    @patch("petl.join")
+    @patch("petl.cut")
+    @patch("petl.sort")
+    @patch("petl.select")
+    def test_run_with_data(
+        self,
+        mock_select,
+        mock_sort,
+        mock_cut,
+        mock_join,
+        mock_fromdicts,
+        mock_tocsv,
+        mock_config,
+        mock_odata_client,
+    ):
+        """Test grind shop open orders report execution with data."""
+        from p21api.report_grind_shop_open_orders import ReportGrindShopOpenOrders
+
+        # Mock order header data
+        order_hdr_data = [
+            {
+                "customer_id": 12096,
+                "order_no": "SO001",
+                "order_date": "2024-01-15",
+                "requested_date": "2024-01-20",
+                "promise_date": "2024-01-25",
+                "taker": "RC",
+                "delete_flag": "N",
+                "completed": "N",
+                "company_id": "CMS",
+            }
+        ]
+
+        # Mock order line data
+        order_line_data = [
+            {
+                "order_no": "SO001",
+                "inv_mast_uid": 123,
+                "qty_ordered": 10,
+                "qty_allocated": 5,
+                "qty_on_pick_tickets": 0,
+                "qty_invoiced": 0,
+                "qty_canceled": 0,
+                "disposition": "Open",
+                "delete_flag": "N",
+                "complete": "N",
+            }
+        ]
+
+        # Mock inventory master data
+        inv_mast_data = [
+            {
+                "inv_mast_uid": 123,
+                "item_id": "KDB001",
+                "item_desc": "Test KDB Item",
+            }
+        ]
+
+        # Mock customer data
+        customer_data = [
+            {
+                "customer_id": 12096,
+                "customer_name": "Test Customer",
+            }
+        ]
+
+        # Configure mock client to return different data for different queries
+        def mock_query_side_effect(
+            endpoint: str, **kwargs: Any
+        ) -> tuple[list[dict[str, Any]], str]:
+            if endpoint == "p21_view_oe_hdr":
+                return order_hdr_data, "url"
+            elif endpoint == "p21_view_oe_line":
+                return order_line_data, "url"
+            elif endpoint == "p21_view_inv_mast":
+                return inv_mast_data, "url"
+            elif endpoint == "p21_view_customer":
+                return customer_data, "url"
+            return [], "url"
+
+        mock_odata_client.query_odataservice.side_effect = mock_query_side_effect
+
+        # Mock petl operations
+        mock_table = Mock()
+        mock_fromdicts.return_value = mock_table
+        mock_join.return_value = mock_table
+        mock_cut.return_value = mock_table
+        mock_sort.return_value = mock_table
+        mock_select.return_value = mock_table
+
+        # Create and run report
+        report = ReportGrindShopOpenOrders(
+            client=mock_odata_client,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            output_folder="test_output/",
+            debug=False,
+            config=mock_config,
+        )
+
+        report.run()
+
+        # Verify the client was called with correct parameters
+        assert mock_odata_client.query_odataservice.call_count >= 4
+
+        # Check that the order header query had correct filters
+        order_hdr_call = mock_odata_client.query_odataservice.call_args_list[0]
+        assert order_hdr_call[1]["endpoint"] == "p21_view_oe_hdr"
+        assert "company_id eq 'CMS'" in order_hdr_call[1]["filters"]
+        assert "taker eq 'RC'" in order_hdr_call[1]["filters"]
+        assert "delete_flag eq 'N'" in order_hdr_call[1]["filters"]
+        assert "completed ne 'Y'" in order_hdr_call[1]["filters"]
+
+    def test_run_with_no_data(self, mock_config, mock_odata_client):
+        """Test grind shop open orders report execution with no data."""
+        from p21api.report_grind_shop_open_orders import ReportGrindShopOpenOrders
+
+        # Configure mock client to return no data
+        mock_odata_client.query_odataservice.return_value = ([], "url")
+
+        # Create and run report
+        report = ReportGrindShopOpenOrders(
+            client=mock_odata_client,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            output_folder="test_output/",
+            debug=False,
+            config=mock_config,
+        )
+
+        # Should return early without error
+        report.run()
+
+        # Should have called query_odataservice at least once
+        assert mock_odata_client.query_odataservice.call_count >= 1


### PR DESCRIPTION
- Implement new report: ReportGrindShopOpenOrders for grind shop open orders.
- Register the report in the config and report groups.
- Add comprehensive unit tests for the new report in tests/reports.